### PR TITLE
🐛 fix: dark mode background gap on zoom and unnecessary scroll on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,5 +4,5 @@
 @tailwind utilities;
 
 body {
-  @apply m-0 p-0;
+  @apply m-0 p-0 bg-white dark:bg-neutral-900;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import YoutubePlayer from './components/YoutubePlayer';
 
 function App() {
   return (
-    <div className="flex flex-col items-center gap-3 bg-white dark:bg-neutral-900 text-gray-800 dark:text-white transition-colors duration-300">
+    <div className="flex flex-col items-center gap-3 bg-white dark:bg-neutral-900 min-h-screen text-gray-800 dark:text-white transition-colors duration-300">
       <NavBar />
       <Timer/>
       <YoutubePlayer />

--- a/src/components/WhiteNoiseButtons.tsx
+++ b/src/components/WhiteNoiseButtons.tsx
@@ -74,7 +74,7 @@ const WhiteNoiseButtons: React.FC = () => {
 
 
   return (
-    <div className="flex flex-col gap-6 mb-50">
+    <div className="flex flex-col gap-6 mb-6">
       <p className="text-base sm:text-xl font-semibold text-gray-800 dark:text-white text-center">White Noise</p>
       <div className="flex flex-row gap-2">
         {Object.keys(sounds).map((key) => {

--- a/src/components/YoutubePlayer.tsx
+++ b/src/components/YoutubePlayer.tsx
@@ -46,7 +46,7 @@ const YoutubePlayer: React.FC = () => {
           )}
           <iframe
             className="w-full h-full"
-            src="https://www.youtube.com/embed/jfKfPfyJRdk?si=DFyWVkUlcOUE4YHx&amp;controls=0"
+            src="https://www.youtube.com/embed/X4VbdwhkE10?si=2csrQ8sJkOY-WwZs&amp;controls=0"
             title="YouTube video player"
             frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
- Add bg color to body and min-h-screen to root div to prevent white band
- Reduce WhiteNoiseButtons bottom margin from mb-50 to mb-6