### PR TITLE
🐛 FIXED: mt-8 to mt-16 on the Timer's container. The navbar is fixed …

### DIFF
--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -64,7 +64,7 @@ const Timer: React.FC = () => {
     };
 
     return (
-        <div className="flex flex-col items-center gap-4 mt-8 sm:mt-20 px-4 w-full">
+        <div className="flex flex-col items-center gap-4 mt-16 sm:mt-20 px-4 w-full">
             <ToastContainer
             position="top-center"
             autoClose={10000}


### PR DESCRIPTION
…and ~56px tall on mobile, but the Timer only had mt-8 (32px), so it was overlapping. mt-16 (64px) gives it enough clearance below the navbar on small screens.